### PR TITLE
ci: adiciona workflow de format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  format:
+    name: Dart format check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter (stable)
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Show Flutter version
+        run: flutter --version
+
+      - name: Check formatting
+        run: dart format --output=none --set-exit-if-changed .


### PR DESCRIPTION
Este PR adiciona o workflow básico de CI no GitHub Actions com verificação de formatação (dart format).

- Roda em PRs para `main` e em pushes na `main`
- Usa Flutter channel stable
- Falha se houver arquivos não formatados

Como testar:
- Abrir esta PR e conferir a aba "Checks" → job "Dart format check" deve executar e passar.